### PR TITLE
Create event logs for streak-related events

### DIFF
--- a/apps/demo/src/app/(textbook)/[slug]/_components/summary/summary-form-skip.tsx
+++ b/apps/demo/src/app/(textbook)/[slug]/_components/summary/summary-form-skip.tsx
@@ -26,6 +26,8 @@ import { SelectIsNextPageVisible } from "@/lib/store/summary-store";
 import { makePageHref, reportSentry } from "@/lib/utils";
 import type { PageData } from "@/lib/pages";
 import type { FormEvent } from "react";
+import { createEventAction } from "@/actions/event";
+import { EventType } from "@/lib/constants";
 
 type Props = {
   pageStatus: PageStatus;
@@ -160,6 +162,17 @@ export const SummaryFormSkip = memo(({ pageStatus, page, streak, available_summa
         <StatusButton
           pending={isPending}
           disabled={pageFinished ? !page.next_slug : false}
+          onClick={() => {
+            if (!pageFinished) {
+              createEventAction({
+                type: EventType.REWARD_SPENT,
+                pageSlug: page.slug,
+                data: {
+                  rewardType: "summary-skip",
+                }
+              });
+            }
+          }}
         >
           {!pageFinished ? (
             <span className="inline-flex items-center gap-1">

--- a/apps/demo/src/lib/constants.ts
+++ b/apps/demo/src/lib/constants.ts
@@ -28,6 +28,8 @@ export const EventType = {
   RANDOM_REREAD: "random_reread",
   SIMPLE: "simple",
   QUIZ: "quiz",
+  STREAK: "streak",
+  REWARD_SPENT: "reward-spent",
 } as const;
 
 export const Condition = {

--- a/apps/demo/src/lib/personalization.ts
+++ b/apps/demo/src/lib/personalization.ts
@@ -1,9 +1,8 @@
 import { User } from "lucia";
 
-import { SKIP_SUMMARY_STREAK_THRESHOLD } from "@/lib/constants";
-import type { PersonalizationData } from "@/drizzle/schema";
 import { createEventAction } from "@/actions/event";
-import { EventType } from "@/lib/constants";
+import { EventType, SKIP_SUMMARY_STREAK_THRESHOLD } from "@/lib/constants";
+import type { PersonalizationData } from "@/drizzle/schema";
 
 export function updatePersonalizationStreak(
   user: User,
@@ -16,11 +15,11 @@ export function updatePersonalizationStreak(
   }
 ): PersonalizationData {
   const personalization = { ...user.personalization };
-  let streakType: string = "unknown";
+
+  let streakType = "";
 
   if (summary) {
     streakType = "summary";
-
     // increment streak count by one if summary is a passing one
     const newSummaryStreak = summary.isPassed
       ? (user.personalization.summary_streak || 0) + 1
@@ -44,11 +43,9 @@ export function updatePersonalizationStreak(
       personalization.available_summary_skips =
         (personalization.available_summary_skips || 0) + 1;
     }
-
   }
   if (cri) {
     streakType = "CRI";
-
     // increment streak count by one if answer is correct
     const newQuestionStreak = cri.isCorrect
       ? (user.personalization.cri_streak || 0) + 1
@@ -59,21 +56,23 @@ export function updatePersonalizationStreak(
     if (newQuestionStreak > (user.personalization.max_cri_streak || 0)) {
       personalization.max_cri_streak = newQuestionStreak;
     }
-
   }
 
-  createEventAction({
-    type: EventType.STREAK,
-    pageSlug: user.pageSlug ?? "Not started",
-    data: {
-      streakType: streakType || "unknown",
-      summaryStreak: personalization.summary_streak || 0,
-      maxSummaryStreak: personalization.max_summary_streak || 0,
-      criStreak: personalization.cri_streak || 0,
-      maxCriStreak: personalization.max_cri_streak || 0,
-      summarySkipCounts: personalization.available_summary_skips || 0,
-    }
-  });
+  // NOTE: don't log events if this is called from admin panel
+  if (!(summary && cri)) {
+    createEventAction({
+      type: EventType.STREAK,
+      pageSlug: user.pageSlug ?? "",
+      data: {
+        streakType: streakType,
+        summaryStreak: personalization.summary_streak || 0,
+        maxSummaryStreak: personalization.max_summary_streak || 0,
+        criStreak: personalization.cri_streak || 0,
+        maxCriStreak: personalization.max_cri_streak || 0,
+        summarySkipCounts: personalization.available_summary_skips || 0,
+      },
+    });
+  }
 
   return personalization;
 }


### PR DESCRIPTION
I think we need logs for
1. When streaks are counted through the `updatePersonalizationStreak` action
2. When streak rewards are expended. Currently through summary skips.

I tried to respect the current pipelines and used the `createEventAction ` and `EventType`. Let me know if this looks okay.